### PR TITLE
Add spiral potential option for scalar field

### DIFF
--- a/include/background.h
+++ b/include/background.h
@@ -19,6 +19,9 @@ enum equation_of_state {CLP,EDE};
 
 enum varconst_dependence {varconst_none,varconst_instant};
 
+/** possible forms of the scalar field potential */
+enum scf_potential {scf_pot_exp_poly, scf_pot_spiral};
+
 /** list of formats for the vector of background quantities */
 
 enum vecback_format {short_info, normal_info, long_info};
@@ -118,6 +121,7 @@ struct background
   double phi_ini_scf;      /**< \f$ \phi(t_0) \f$: scalar field initial value */
   double phi_prime_ini_scf;/**< \f$ d\phi(t_0)/d\tau \f$: scalar field initial derivative wrt conformal time */
   int scf_parameters_size; /**< size of scf_parameters */
+  enum scf_potential scf_potential; /**< form of scalar field potential */
   double varconst_alpha; /**< finestructure constant for varying fundamental constants */
   double varconst_me; /**< electron mass for varying fundamental constants */
   enum varconst_dependence varconst_dep; /**< dependence of the varying fundamental constants as a function of time */

--- a/source/background.c
+++ b/source/background.c
@@ -2905,10 +2905,6 @@ double V_e_scf(struct background *pba,
                double phi
                ) {
   double scf_lambda = pba->scf_parameters[0];
-  //  double scf_alpha  = pba->scf_parameters[1];
-  //  double scf_A      = pba->scf_parameters[2];
-  //  double scf_B      = pba->scf_parameters[3];
-
   return  exp(-scf_lambda*phi);
 }
 
@@ -2985,17 +2981,50 @@ double ddV_p_scf(
 double V_scf(
              struct background *pba,
              double phi) {
+  if (pba->scf_potential == scf_pot_spiral) {
+    double alpha = pba->scf_parameters[0];
+    double lambda = pba->scf_parameters[1];
+    double beta = pba->scf_parameters[2];
+    double gamma = pba->scf_parameters[3];
+    double k = pba->scf_parameters[4];
+    double omega = pba->scf_parameters[5];
+    double delta = pba->scf_parameters[6];
+    double psi0 = pba->scf_parameters[7];
+    double theta_val = _PI_;
+    double t_val = 0.5;
+    return alpha*exp(-lambda*phi) + beta*phi*phi +
+           gamma*cos(k*theta_val - omega*t_val) +
+           delta*pow(log(phi/psi0),2);
+  }
   return  V_e_scf(pba,phi)*V_p_scf(pba,phi);
 }
 
 double dV_scf(
               struct background *pba,
               double phi) {
+  if (pba->scf_potential == scf_pot_spiral) {
+    double alpha = pba->scf_parameters[0];
+    double lambda = pba->scf_parameters[1];
+    double beta = pba->scf_parameters[2];
+    double delta = pba->scf_parameters[6];
+    double psi0 = pba->scf_parameters[7];
+    return -alpha*lambda*exp(-lambda*phi) + 2.*beta*phi +
+           2.*delta*log(phi/psi0)/phi;
+  }
   return dV_e_scf(pba,phi)*V_p_scf(pba,phi) + V_e_scf(pba,phi)*dV_p_scf(pba,phi);
 }
 
 double ddV_scf(
                struct background *pba,
                double phi) {
+  if (pba->scf_potential == scf_pot_spiral) {
+    double alpha = pba->scf_parameters[0];
+    double lambda = pba->scf_parameters[1];
+    double beta = pba->scf_parameters[2];
+    double delta = pba->scf_parameters[6];
+    double psi0 = pba->scf_parameters[7];
+    return alpha*lambda*lambda*exp(-lambda*phi) + 2.*beta +
+           2.*delta*(1.-log(phi/psi0))/(phi*phi);
+  }
   return ddV_e_scf(pba,phi)*V_p_scf(pba,phi) + 2*dV_e_scf(pba,phi)*dV_p_scf(pba,phi) + V_e_scf(pba,phi)*ddV_p_scf(pba,phi);
 }

--- a/source/input.c
+++ b/source/input.c
@@ -3313,6 +3313,22 @@ int input_read_parameters_species(struct file_content * pfc,
                                            errmsg),
                errmsg,errmsg);
 
+    /* Potential form */
+    class_call(parser_read_string(pfc,
+                                  "scf_potential",
+                                  &string1,
+                                  &flag1,
+                                  errmsg),
+               errmsg,errmsg);
+    if (flag1 == _TRUE_) {
+      if ((strstr(string1,"spiral") != NULL) || (strstr(string1,"SPIRAL") != NULL)) {
+        pba->scf_potential = scf_pot_spiral;
+      }
+      else {
+        pba->scf_potential = scf_pot_exp_poly;
+      }
+    }
+
     /** 8.b.2) SCF initial conditions from attractor solution */
     /* Read */
     class_call(parser_read_string(pfc,
@@ -5907,6 +5923,7 @@ int input_default_params(struct background *pba,
   /** 9.b.1) Potential parameters and initial conditions */
   pba->scf_parameters = NULL;
   pba->scf_parameters_size = 0;
+  pba->scf_potential = scf_pot_exp_poly;
   /** 9.b.2) Initial conditions from attractor solution */
   pba->attractor_ic_scf = _TRUE_;
   pba->phi_ini_scf = 1;                // MZ: initial conditions are as multiplicative


### PR DESCRIPTION
## Summary
- add enumeration for scalar field potential types
- store chosen potential in background struct
- allow selecting new `spiral` potential in `input.c`
- implement `scf_pot_spiral` in background potential functions

## Testing
- `make libclass.a -j2`


------
https://chatgpt.com/codex/tasks/task_e_6845d2e530188320b6773f459c55517b