### PR TITLE
Expose scf_potential in classy

### DIFF
--- a/python/README
+++ b/python/README
@@ -12,4 +12,9 @@ You can check that these steps worked by typing
 > python
 >>> from classy import Class
 
-If python does not complain, the Class module has been correctly installed in your python distribution. You can now import it and use its functions from your python codes.  
+If python does not complain, the Class module has been correctly installed in your python distribution. You can now import it and use its functions from your python codes.
+
+The wrapper also exposes the scalar field potential choice through the
+``scf_potential`` entry of the parameter dictionary.  It accepts either
+``exp_poly`` (the default) or ``spiral`` and forwards this value to the
+underlying CLASS code.

--- a/python/cclassy.pxd
+++ b/python/cclassy.pxd
@@ -50,6 +50,10 @@ cdef extern from "class.h":
         out_sigma_prime
         out_sigma_disp
 
+    cdef enum scf_potential:
+        scf_pot_exp_poly
+        scf_pot_spiral
+
     cdef struct precision:
         double nonlinear_min_k_max
         ErrorMsg error_message
@@ -107,6 +111,7 @@ cdef extern from "class.h":
         double H_eq
         double z_eq
         double tau_eq
+        scf_potential scf_potential
 
     cdef struct thermodynamics:
         short is_allocated

--- a/python/classy.pyx
+++ b/python/classy.pyx
@@ -126,6 +126,10 @@ cdef class Class:
         def __get__(self):
             return self.fo.method
 
+    property scf_potential:
+        def __get__(self):
+            return self.ba.scf_potential
+
     def set_default(self):
         _pars = {
             "output":"tCl mPk",}


### PR DESCRIPTION
## Summary
- export `scf_potential` in `cclassy.pxd`
- add a `scf_potential` property in `classy.pyx`
- document how to use it in `python/README`
- build wrapper to verify compilation

## Testing
- `python setup.py build_ext --inplace`
- `python - <<'EOF'
import classy
c=classy.Class()
print('scf_potential attribute exists:', hasattr(c,'scf_potential'))
EOF`
- `python test_class.py --help` *(fails: ModuleNotFoundError: No module named 'imp')*

------
https://chatgpt.com/codex/tasks/task_e_68467f52184c8320be3c3f1a40022f43